### PR TITLE
Dashboard: single Forecast line (move original under Advanced)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,13 @@ pytest tests/test_rules.py                # single file
 pytest tests/test_rules.py::test_thermik_go  # single test
 ruff check src tests
 mypy src
+
+# Real dashboard traffic (bot-filtered, IPv6 /64-deduped) — for sizing rollout reach
+python3 scripts/dashboard_traffic.py            # last 30d, prod
+python3 scripts/dashboard_traffic.py --days 7   # shorter window
 ```
+
+To measure **actual visitors** to the live dashboard, use `scripts/dashboard_traffic.py` — do **not** hand-roll `gcloud logging read | sort -u` IP counts, which overcount ~4× (AI crawlers like GPTBot send browser-ish UAs; one-off scanner IPs read as visitors). The script pulls Cloud Run GET logs, drops bots / exploit-scanner paths / empty-UA probes, and dedupes IPv6 by /64 (flagging m-net's `2001:a61::/32`, which rotates the customer /48 so one person spans several /64s). Run it the day after each rollout step to see what a channel actually delivered.
 
 Storage backend is selected by env: `RUNS_BUCKET` set → `GCSRunStore` (writes `gs://$RUNS_BUCKET/runs/<iso>.json`); unset → `LocalRunStore` at `data/runs/`. Both implement the same `RunStore` protocol in `src/oracle/logger.py` — tests and local dev stay on the filesystem without needing GCP creds.
 

--- a/src/oracle/dashboard/main.py
+++ b/src/oracle/dashboard/main.py
@@ -142,7 +142,8 @@ _RULE_I18N: dict[str, RuleI18n] = {
 _UI: dict[str, dict[str, str]] = {
     "de": {
         "strip_forecast": "Vorhersage",
-        "strip_resimulated": "Neu berechnet (mit heutigen Regeln)",
+        "strip_forecast_original": "Vergangene Vorhersageart",
+        "strip_forecast_original_note": "Wie der Tag damals vorhergesagt wurde, vor der Nachkalibrierung der Regeln — nur zum Vergleich.",
         "strip_actual": "Tatsächlich (Session ≥ 1 h)",
         "strip_legend_go": "Session (≥ 1 h ≥ 11 kt)",
         "strip_legend_maybe": "marginal (≥ 1 h ≥ 8 kt)",
@@ -174,7 +175,6 @@ _UI: dict[str, dict[str, str]] = {
         "no_data_headline": "—",
         "advanced_label": "Details — alle 12 Regeln",
         "view_label_original": "wie damals geschrieben",
-        "view_label_resimulated": "neu berechnet",
         "col_rule": "Regel",
         "col_signal": "Signal",
         "col_reason": "Begründung",
@@ -187,7 +187,8 @@ _UI: dict[str, dict[str, str]] = {
     },
     "en": {
         "strip_forecast": "Forecast",
-        "strip_resimulated": "Re-scored (current aggregator)",
+        "strip_forecast_original": "Previous forecast method",
+        "strip_forecast_original_note": "How the day was forecast at the time, before the rules were recalibrated — shown for comparison only.",
         "strip_actual": "Actual (session ≥ 1 h)",
         "strip_legend_go": "session (≥ 1 h ≥ 11 kt)",
         "strip_legend_maybe": "marginal (≥ 1 h ≥ 8 kt)",
@@ -219,7 +220,6 @@ _UI: dict[str, dict[str, str]] = {
         "no_data_headline": "—",
         "advanced_label": "Advanced — all 12 rules",
         "view_label_original": "as written at the time",
-        "view_label_resimulated": "re-scored",
         "col_rule": "Rule",
         "col_signal": "Signal",
         "col_reason": "Reason",

--- a/src/oracle/dashboard/templates/index.html
+++ b/src/oracle/dashboard/templates/index.html
@@ -191,6 +191,7 @@
   }
   .advanced-panel { display: none; background: var(--panel); border-radius: 8px; padding: 4px 20px 16px; margin-top: 8px; }
   .advanced-toggle:checked ~ .advanced-panel { display: block; }
+  .advanced-note { color: var(--muted); font-size: 12px; margin: 4px 0 12px; }
 
   table { width: 100%; border-collapse: collapse; margin-top: 12px; font-size: 13px; }
   th, td { text-align: left; padding: 6px 10px; border-bottom: 1px solid var(--border); vertical-align: top; }
@@ -331,8 +332,8 @@
     </h2>
     <p class="verdict-summary">{{ summary }}</p>
     <div class="verdict-meta">
-      {{ t.for_day }} {{ selected_date_label }} —
-      <span class="view-tag">{% if view == 'original' %}{{ t.view_label_original }}{% else %}{{ t.view_label_resimulated }}{% endif %}</span>.
+      {{ t.for_day }} {{ selected_date_label }}{% if view == 'original' %} —
+      <span class="view-tag">{{ t.view_label_original }}</span>{% endif %}.
     </div>
   </section>
 
@@ -349,29 +350,13 @@
   <div class="strip-row-label">{{ t.strip_forecast }}</div>
   <div class="strip">
     {% for d in history %}
-      {% set sel = (d.iso == selected_iso and view == 'original') %}
-      {% if d.verdict %}
-        <a class="cell {{ d.verdict }}{% if sel %} selected{% endif %}"
-           href="?day={{ d.iso }}&view=original"
-           title="{{ d.day }} — {{ t.strip_forecast }}: {{ d.verdict }}"></a>
-      {% else %}
-        <div class="cell empty" title="{{ d.day }} — {{ t.strip_forecast }}: —"></div>
-      {% endif %}
-    {% endfor %}
-  </div>
-</div>
-
-<div class="strip-row">
-  <div class="strip-row-label">{{ t.strip_resimulated }}</div>
-  <div class="strip">
-    {% for d in history %}
       {% set sel = (d.iso == selected_iso and view == 'resimulated') %}
       {% if d.resimulated %}
         <a class="cell {{ d.resimulated }}{% if sel %} selected{% endif %}"
            href="?day={{ d.iso }}&view=resimulated"
-           title="{{ d.day }} — {{ t.strip_resimulated }}: {{ d.resimulated }}"></a>
+           title="{{ d.day }} — {{ t.strip_forecast }}: {{ d.resimulated }}"></a>
       {% else %}
-        <div class="cell empty" title="{{ d.day }} — {{ t.strip_resimulated }}: —"></div>
+        <div class="cell empty" title="{{ d.day }} — {{ t.strip_forecast }}: —"></div>
       {% endif %}
     {% endfor %}
   </div>
@@ -412,6 +397,23 @@
 <label for="advanced" class="advanced-label">{{ t.advanced_label }}</label>
 
 <div class="advanced-panel">
+  <div class="strip-row">
+    <div class="strip-row-label">{{ t.strip_forecast_original }}</div>
+    <div class="strip">
+      {% for d in history %}
+        {% set sel = (d.iso == selected_iso and view == 'original') %}
+        {% if d.verdict %}
+          <a class="cell {{ d.verdict }}{% if sel %} selected{% endif %}"
+             href="?day={{ d.iso }}&view=original"
+             title="{{ d.day }} — {{ t.strip_forecast_original }}: {{ d.verdict }}"></a>
+        {% else %}
+          <div class="cell empty" title="{{ d.day }} — {{ t.strip_forecast_original }}: —"></div>
+        {% endif %}
+      {% endfor %}
+    </div>
+  </div>
+  <p class="advanced-note">{{ t.strip_forecast_original_note }}</p>
+
   <table>
     <thead><tr><th>{{ t.col_rule }}</th><th>{{ t.col_signal }}</th><th>{{ t.col_reason }}</th></tr></thead>
     <tbody>


### PR DESCRIPTION
## What
Discord beta testers (Anton) were confused by the two forecast rows in the 30-day strip — `Vorhersage` (original, as-written) vs `Neu berechnet` (re-scored). This collapses them into **one** primary "Vorhersage / Forecast" line (the re-scored one), and moves the original as-written row behind the **Advanced** toggle as *Vergangene Vorhersageart* with an explanatory note.

## Changes
- Primary strip row now binds to the re-scored verdicts, labeled `strip_forecast`.
- Original (`view=original`) row relocated into the Advanced panel + caption.
- Hero drops the `re-scored` qualifier in the default view (shown only when inspecting an original cell).
- Removed unused `strip_resimulated` / `view_label_resimulated` strings.
- Also documents `scripts/dashboard_traffic.py` in CLAUDE.md (separate commit).

## Verification
- Rendered against prod data (`RUNS_BUCKET=walchi-oracle-prod-runs`): default view shows Forecast + Actual; Advanced reveals the original row + note; cell-clicks and DE/EN toggle work.
- `ruff` clean, `mypy` unchanged (2 pre-existing errors in untouched files), 102 tests pass.