### PR TITLE
Dashboard: hide GitHub link on pseudonymous (s1st.de) host

### DIFF
--- a/src/oracle/dashboard/main.py
+++ b/src/oracle/dashboard/main.py
@@ -786,6 +786,12 @@ async def index(request: Request) -> Response:
         display_overall = None
         display_verdicts = []
 
+    # The GitHub repo carries the author's real name (commit authors, LICENSE),
+    # so suppress the source link on the pseudonymous host (s1st.de) while
+    # keeping it on the real-name face (simon-stieber.de) and in local/dev.
+    host = (request.headers.get("host") or "").split(":")[0].lower()
+    show_github = not host.endswith("s1st.de")
+
     summary = _summary_line(display_overall, display_verdicts, lang) if raw else ""
     tooltips = _TOOLTIPS_BY_LANG[lang]
     rule_labels = _LABELS_BY_LANG[lang]
@@ -814,6 +820,7 @@ async def index(request: Request) -> Response:
             "is_today": is_today,
             "t": _UI[lang],
             "lang": lang,
+            "show_github": show_github,
         },
     )
     q = request.query_params.get("lang")

--- a/src/oracle/dashboard/templates/index.html
+++ b/src/oracle/dashboard/templates/index.html
@@ -238,9 +238,11 @@
 <nav class="lang-toggle">
   <a href="?lang=de" class="{% if lang == 'de' %}active{% endif %}" aria-label="Deutsch">🇩🇪</a>
   <a href="?lang=en" class="{% if lang == 'en' %}active{% endif %}" aria-label="English">🇬🇧</a>
+  {% if show_github %}
   <a class="gh" href="https://github.com/s1st/walchensee-oracle" target="_blank" rel="noopener" aria-label="Source on GitHub">
     <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 0 0 5.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8"/></svg>
   </a>
+  {% endif %}
 </nav>
 
 <h1>Walchi Oracle</h1>


### PR DESCRIPTION
Keeps the public/anon face (`walchensee.s1st.de`) from linking the repo, which exposes the real name via commit authors + LICENSE. Link stays on `walchensee.simon-stieber.de` and in local/dev. Host-based `show_github` flag; ruff clean, 102 tests pass.