### PR TITLE
Quarantine thunderstorm days from calibration + flag them in the dashboard

### DIFF
--- a/src/oracle/calibration.py
+++ b/src/oracle/calibration.py
@@ -24,8 +24,9 @@ from dataclasses import dataclass, field
 from datetime import date, datetime
 from pathlib import Path
 
+from oracle import config
 from oracle.engine import aggregate, apply_rules
-from oracle.knowledge.rules import SIGNAL_ORDER, Signal, Verdict
+from oracle.knowledge.rules import SIGNAL_ORDER, Signal, Verdict, is_storm_risk
 from oracle.logger import RunStore, default_store, verdict_to_dict
 from oracle.pillars.measurements import WindReading
 from oracle.pillars.meteo import MeteoSnapshot
@@ -116,6 +117,7 @@ class Report:
     rule_stats: dict[str, RuleStats] = field(default_factory=dict)
     label_mode: str = "peak"
     resimulated: bool = False
+    quarantined_days: list[str] = field(default_factory=list)  # storm-suspected, excluded
 
     @property
     def overall_accuracy(self) -> float:
@@ -144,6 +146,22 @@ def _peak_from(record: dict) -> float | None:
 
 def _machine_from(record: dict) -> dict | None:
     return (record.get("ground_truth") or {}).get("machine") or None
+
+
+def storm_suspected(record: dict) -> bool:
+    """Forecast-time thunderstorm flag for a stored record, read from the lifted
+    index in its meteo inputs.
+
+    Drives both the calibration quarantine in `compile_report` and the
+    dashboard's yellow storm border. Storm days are excluded from the confusion
+    matrix and per-rule offender stats: the high wind a gust front delivers is
+    not a thermal session, so counting it would punish the very rules that
+    correctly vetoed the storm (e.g. `atmospheric_stability`). Defensive against
+    legacy records written before the lifted-index field existed.
+    """
+    meteo = (record.get("inputs") or {}).get("meteo") or {}
+    li = meteo.get("min_lifted_index")
+    return li is not None and is_storm_risk(float(li))
 
 
 def _label_record(record: dict, mode: str) -> str | None:
@@ -291,6 +309,7 @@ def compile_report(
     confusion = _empty_confusion()
     rule_stats: dict[str, RuleStats] = {}
     sample_days: list[str] = []
+    quarantined: list[str] = []
 
     for iso in _iter_window_days(store, since, until):
         record = store.read(iso)
@@ -303,6 +322,11 @@ def compile_report(
         if forecast not in confusion:
             # Unknown overall — skip rather than crash on legacy data, or on
             # records that haven't been rescored yet when --resimulated is set.
+            continue
+        if storm_suspected(record):
+            # Gust-front wind isn't a thermal session; learning from it would
+            # punish the rules that correctly vetoed the storm. Quarantine it.
+            quarantined.append(iso)
             continue
         confusion[forecast][actual] += 1
         sample_days.append(iso)
@@ -325,16 +349,23 @@ def compile_report(
         rule_stats=rule_stats,
         label_mode=label,
         resimulated=resimulated,
+        quarantined_days=quarantined,
     )
 
 
 def format_text_report(report: Report, rule_filter: str | None = None) -> str:
     """Plain-text summary suitable for `oracle calibrate` stdout."""
     if report.sample_size == 0:
-        return (
+        msg = (
             "No days with ground truth yet. Run `oracle backfill` to merge "
             "Urfeld peak data into the day's forecast log first."
         )
+        if report.quarantined_days:
+            msg += (
+                f" ({len(report.quarantined_days)} storm-suspected day(s) "
+                "quarantined — see `oracle backfill`.)"
+            )
+        return msg
 
     label_desc = {
         "peak": "peak avg ≥12 kt → GO, ≥8 kt → MAYBE",
@@ -347,6 +378,12 @@ def format_text_report(report: Report, rule_filter: str | None = None) -> str:
         f"Calibration sample: {report.sample_size} days with ground truth "
         f"(label = {report.label_mode}: {label_desc}; view = {view})."
     )
+    if report.quarantined_days:
+        lines.append(
+            f"  ⚡ {len(report.quarantined_days)} storm-suspected day(s) quarantined "
+            f"(LI ≤ {config.MIN_LIFTED_INDEX:.0f}) — excluded from the matrix and "
+            "offender stats; gust-front wind isn't a thermal session."
+        )
     if report.sample_size < 14:
         lines.append(
             "  ⚠  small sample — interpret with caution. Wait for "
@@ -413,6 +450,9 @@ _CSV_COLUMNS = [
     "peak_avg_knots", "peak_gust_knots",
     "first_ignition_minute", "samples_above_8kt", "samples_above_12kt",
     "actual_verdict",
+    # storm flag: True = gust-front-contaminated label, quarantined from calibration.
+    # Kept in the export (not dropped) so the ML notebook can mask or model it.
+    "storm_suspected",
     # what the rule layer said (for benchmarking ML against the heuristic)
     "forecast_overall", "forecast_overall_resimulated",
 ]
@@ -456,6 +496,7 @@ def _row_for(record: dict) -> dict | None:
         "samples_above_8kt": machine.get("samples_above_8kt"),
         "samples_above_12kt": machine.get("samples_above_12kt"),
         "actual_verdict": actual_verdict(peak),
+        "storm_suspected": storm_suspected(record),
         "forecast_overall": record.get("overall"),
         "forecast_overall_resimulated": record.get("overall_resimulated"),
     }

--- a/src/oracle/dashboard/main.py
+++ b/src/oracle/dashboard/main.py
@@ -24,6 +24,7 @@ from fastapi.responses import HTMLResponse, Response
 from fastapi.templating import Jinja2Templates
 
 from oracle.calibration import actual_verdict_duration as _actual_verdict_duration
+from oracle.calibration import storm_suspected as _storm_suspected
 from oracle.knowledge.rules import Severity, Signal
 from oracle.logger import RunStore, default_store
 from oracle.pillars.measurements import UrfeldSample, fetch_urfeld_day_curve
@@ -149,6 +150,8 @@ _UI: dict[str, dict[str, str]] = {
         "strip_legend_maybe": "marginal (≥ 1 h ≥ 8 kt)",
         "strip_legend_no_go": "kein Wind",
         "strip_legend_empty": "keine Daten",
+        "strip_legend_storm": "Gewitter (aus Kalibrierung ausgenommen)",
+        "storm_hint": "⚡ Gewitter-Risiko — kein Thermik-Tag",
         "live_header": "Aktuell in Urfeld",
         "live_now": "jetzt",
         "live_gust_label": "Böe",
@@ -194,6 +197,8 @@ _UI: dict[str, dict[str, str]] = {
         "strip_legend_maybe": "marginal (≥ 1 h ≥ 8 kt)",
         "strip_legend_no_go": "no wind",
         "strip_legend_empty": "no data",
+        "strip_legend_storm": "thunderstorm (excluded from calibration)",
+        "storm_hint": "⚡ thunderstorm risk — not a thermal day",
         "live_header": "Live at Urfeld",
         "live_now": "now",
         "live_gust_label": "gust",
@@ -278,6 +283,7 @@ def _horizon_days(today: date, lang: str, selected_iso: str) -> list[dict]:
             "short_date": _fmt_date(d, lang, "short"),
             "verdict": record.get("overall") if record else None,
             "selected": d.isoformat() == selected_iso,
+            "storm": _storm_suspected(record) if record else False,
         })
     return out
 
@@ -610,6 +616,7 @@ def _history(today: date, lang: str, days: int = 30) -> list[dict]:
             "resimulated": resimulated,
             "peak_avg_knots": peak,
             "actual": _actual_verdict_duration(machine),
+            "storm": _storm_suspected(record) if record else False,
         })
     return items
 

--- a/src/oracle/dashboard/templates/index.html
+++ b/src/oracle/dashboard/templates/index.html
@@ -66,6 +66,9 @@
   .day-tab.dot-go::after    { background: var(--go); }
   .day-tab.dot-maybe::after { background: var(--maybe); }
   .day-tab.dot-no_go::after { background: var(--no-go); }
+  /* Thunderstorm-forecast day: black+yellow dashed "hazard" ring so it reads as
+     a warning, not a verdict colour. Dash gaps reveal the dark page background. */
+  .day-tab.storm { outline: 2px dashed var(--maybe); outline-offset: 2px; }
 
   .live-panel {
     display: grid; grid-template-columns: 1.2fr 1fr; gap: 12px;
@@ -155,6 +158,13 @@
   .cell.maybe { background: var(--maybe); }
   .cell.no_go { background: var(--no-go); }
   .cell.empty { background: var(--panel); opacity: .35; }
+  /* Thunderstorm-forecast day: a black border with a yellow dashed outline laid
+     over it = black/yellow hazard dashes. Stays legible even on a yellow MAYBE
+     fill, where a plain yellow border would disappear. */
+  .cell.storm {
+    border: 2px solid #000;
+    outline: 2px dashed var(--maybe); outline-offset: -2px;
+  }
   .view-tag { font-style: italic; opacity: .8; }
   .strip-labels { display: flex; justify-content: space-between; color: var(--muted); font-size: 11px; }
   .strip-legend {
@@ -169,6 +179,7 @@
   .strip-legend i.maybe { background: var(--maybe); }
   .strip-legend i.no_go { background: var(--no-go); }
   .strip-legend i.empty { background: var(--panel); border: 1px solid var(--border); }
+  .strip-legend i.storm { background: #000; border: 1px dashed var(--maybe); }
 
   .advanced-toggle { display: none; }
   .advanced-label {
@@ -317,7 +328,8 @@
 <nav class="day-tabs">
   {% for d in horizon %}
     <a href="?day={{ d.iso }}{% if lang %}&lang={{ lang }}{% endif %}"
-       class="day-tab {% if d.selected %}selected{% endif %} {% if d.verdict %}dot-{{ d.verdict }}{% endif %}">
+       class="day-tab {% if d.selected %}selected{% endif %} {% if d.verdict %}dot-{{ d.verdict }}{% endif %}{% if d.storm %} storm{% endif %}"
+       {% if d.storm %}title="{{ t.storm_hint }}"{% endif %}>
       <span class="day-tab-label">{{ d.label }}</span>
       <span class="day-tab-date">{{ d.short_date }}</span>
     </a>
@@ -354,11 +366,11 @@
     {% for d in history %}
       {% set sel = (d.iso == selected_iso and view == 'resimulated') %}
       {% if d.resimulated %}
-        <a class="cell {{ d.resimulated }}{% if sel %} selected{% endif %}"
+        <a class="cell {{ d.resimulated }}{% if sel %} selected{% endif %}{% if d.storm %} storm{% endif %}"
            href="?day={{ d.iso }}&view=resimulated"
-           title="{{ d.day }} — {{ t.strip_forecast }}: {{ d.resimulated }}"></a>
+           title="{{ d.day }} — {{ t.strip_forecast }}: {{ d.resimulated }}{% if d.storm %} · {{ t.storm_hint }}{% endif %}"></a>
       {% else %}
-        <div class="cell empty" title="{{ d.day }} — {{ t.strip_forecast }}: —"></div>
+        <div class="cell empty{% if d.storm %} storm{% endif %}" title="{{ d.day }} — {{ t.strip_forecast }}: —{% if d.storm %} · {{ t.storm_hint }}{% endif %}"></div>
       {% endif %}
     {% endfor %}
   </div>
@@ -370,13 +382,13 @@
     {% for d in history %}
       {% set sel = (d.iso == selected_iso) %}
       {% if d.actual %}
-        <a class="cell {{ d.actual }}{% if sel %} selected{% endif %}"
+        <a class="cell {{ d.actual }}{% if sel %} selected{% endif %}{% if d.storm %} storm{% endif %}"
            href="?day={{ d.iso }}&view={{ view }}"
-           title="{{ d.day }} — {{ t.strip_actual }}: {% if d.peak_avg_knots %}{{ '%.1f'|format(d.peak_avg_knots) }} kt peak{% else %}—{% endif %}"></a>
+           title="{{ d.day }} — {{ t.strip_actual }}: {% if d.peak_avg_knots %}{{ '%.1f'|format(d.peak_avg_knots) }} kt peak{% else %}—{% endif %}{% if d.storm %} · {{ t.storm_hint }}{% endif %}"></a>
       {% else %}
-        <a class="cell empty{% if sel %} selected{% endif %}"
+        <a class="cell empty{% if sel %} selected{% endif %}{% if d.storm %} storm{% endif %}"
            href="?day={{ d.iso }}&view={{ view }}"
-           title="{{ d.day }} — {{ t.strip_actual }}: —"></a>
+           title="{{ d.day }} — {{ t.strip_actual }}: —{% if d.storm %} · {{ t.storm_hint }}{% endif %}"></a>
       {% endif %}
     {% endfor %}
   </div>
@@ -392,6 +404,7 @@
   <span><i class="maybe"></i>{{ t.strip_legend_maybe }}</span>
   <span><i class="no_go"></i>{{ t.strip_legend_no_go }}</span>
   <span><i class="empty"></i>{{ t.strip_legend_empty }}</span>
+  <span><i class="storm"></i>{{ t.strip_legend_storm }}</span>
 </div>
 
 {% if current %}
@@ -405,11 +418,11 @@
       {% for d in history %}
         {% set sel = (d.iso == selected_iso and view == 'original') %}
         {% if d.verdict %}
-          <a class="cell {{ d.verdict }}{% if sel %} selected{% endif %}"
+          <a class="cell {{ d.verdict }}{% if sel %} selected{% endif %}{% if d.storm %} storm{% endif %}"
              href="?day={{ d.iso }}&view=original"
-             title="{{ d.day }} — {{ t.strip_forecast_original }}: {{ d.verdict }}"></a>
+             title="{{ d.day }} — {{ t.strip_forecast_original }}: {{ d.verdict }}{% if d.storm %} · {{ t.storm_hint }}{% endif %}"></a>
         {% else %}
-          <div class="cell empty" title="{{ d.day }} — {{ t.strip_forecast_original }}: —"></div>
+          <div class="cell empty{% if d.storm %} storm{% endif %}" title="{{ d.day }} — {{ t.strip_forecast_original }}: —{% if d.storm %} · {{ t.storm_hint }}{% endif %}"></div>
         {% endif %}
       {% endfor %}
     </div>

--- a/src/oracle/knowledge/rules.py
+++ b/src/oracle/knowledge/rules.py
@@ -187,6 +187,20 @@ def post_rain_moisture(meteo: MeteoSnapshot) -> Verdict:
     )
 
 
+def is_storm_risk(min_lifted_index: float) -> bool:
+    """True when convective instability is high enough to flag thunderstorm risk.
+
+    Single source of truth for three things that must agree: the
+    `atmospheric_stability` HARD veto below, the calibration storm-quarantine
+    (`calibration.storm_suspected`), and the dashboard's yellow storm border.
+    Keyed on the lifted index (≤ MIN_LIFTED_INDEX) — the project's existing
+    thunderstorm signal. CAPE and target-day precipitation are captured but not
+    yet folded in (see config.py); tighten here when calibrated, and all three
+    consumers move together.
+    """
+    return min_lifted_index <= config.MIN_LIFTED_INDEX
+
+
 def atmospheric_stability(meteo: MeteoSnapshot) -> Verdict:
     lo, hi = meteo.min_lifted_index, meteo.max_lifted_index
     if hi >= config.MAX_LIFTED_INDEX:
@@ -196,7 +210,7 @@ def atmospheric_stability(meteo: MeteoSnapshot) -> Verdict:
             reason_de=f"LI {hi:.1f} — Atmosphäre zu stabil, Thermik gedeckelt",
             severity=Severity.SOFT,
         )
-    if lo <= config.MIN_LIFTED_INDEX:
+    if is_storm_risk(lo):
         return Verdict(
             "atmospheric_stability", Signal.NO_GO,
             reason_en=f"LI {lo:.1f} — thunderstorm risk destroys the thermal",

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -11,6 +11,7 @@ from oracle.calibration import (
     format_text_report,
     rescore_all,
     rescore_record,
+    storm_suspected,
 )
 from oracle.logger import LocalRunStore
 
@@ -128,6 +129,46 @@ def test_false_positive_veto_attribution(tmp_path: Path):
     # `worst_offenders` should rank this rule first.
     worst = report.worst_offenders()
     assert worst and worst[0].rule == "post_rain_moisture"
+
+
+def test_storm_suspected_reads_lifted_index():
+    assert storm_suspected({"inputs": _full_inputs(day="2026-06-01", li_min=-3.0)}) is True
+    assert storm_suspected({"inputs": _full_inputs(day="2026-06-01", li_min=1.0)}) is False
+    # Legacy record with no meteo inputs → can't tell → not a storm (keep the day).
+    assert storm_suspected({"day": "2026-06-01"}) is False
+
+
+def test_compile_report_quarantines_storm_days(tmp_path: Path):
+    store = LocalRunStore(tmp_path)
+    # Storm day: forecast NO_GO via the atmospheric_stability HARD veto, but the
+    # Urfeld gust front peaked at 16 kt, which the peak label calls GO. This must
+    # be quarantined — otherwise atmospheric_stability is charged a false-positive
+    # veto for correctly calling the storm.
+    store.write("2026-06-01", {
+        "day": "2026-06-01",
+        "overall": "no_go",
+        "verdicts": [_verdict("atmospheric_stability", "no_go", "hard")],
+        "inputs": _full_inputs(day="2026-06-01", li_min=-3.0),
+        "ground_truth": {"machine": {"peak_avg_knots": 16.0}, "human": None},
+    })
+    # Clear-air day: a genuine thermal that post_rain_moisture over-vetoed.
+    store.write("2026-06-02", {
+        "day": "2026-06-02",
+        "overall": "no_go",
+        "verdicts": [_verdict("post_rain_moisture", "no_go", "soft")],
+        "inputs": _full_inputs(day="2026-06-02", li_min=1.0),
+        "ground_truth": {"machine": {"peak_avg_knots": 14.0}, "human": None},
+    })
+
+    report = compile_report(store=store)
+    assert report.quarantined_days == ["2026-06-01"]
+    assert report.sample_size == 1
+    assert report.days_with_ground_truth == ["2026-06-02"]
+    # Storm rule was NOT charged a false-positive veto…
+    assert "atmospheric_stability" not in report.rule_stats
+    # …while the genuine over-veto on the clear-air day still surfaces.
+    assert report.rule_stats["post_rain_moisture"].false_positive_vetos == 1
+    assert "quarantined" in format_text_report(report)
 
 
 def test_format_text_report_handles_empty(tmp_path: Path):
@@ -282,6 +323,7 @@ def test_export_csv_writes_features_and_ground_truth(tmp_path: Path):
     assert row["samples_above_8kt"] == "18"
     assert row["samples_above_12kt"] == "6"
     assert row["actual_verdict"] == "go"
+    assert row["storm_suspected"] == "False"  # li_min default 1.0 → clear air
     assert row["forecast_overall"] == "go"
 
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -10,6 +10,7 @@ from oracle.knowledge.rules import (
     daytime_clouds,
     dew_point_spread,
     foehn_override,
+    is_storm_risk,
     overnight_cooling,
     post_rain_moisture,
     solar_radiation,
@@ -157,6 +158,17 @@ def test_atmospheric_stability_storm_risk_no_go():
 
 def test_atmospheric_stability_normal_go():
     assert atmospheric_stability(_meteo(max_li=3.0, min_li=1.0)).signal is Signal.GO
+
+
+def test_is_storm_risk_matches_atmospheric_stability_hard_veto():
+    # The predicate must agree with the rule's HARD branch at the threshold:
+    # LI ≤ MIN_LIFTED_INDEX (−2) is a storm; just above it is not.
+    assert is_storm_risk(-3.0) is True
+    assert is_storm_risk(-2.0) is True
+    assert is_storm_risk(-1.9) is False
+    assert (
+        atmospheric_stability(_meteo(max_li=0.0, min_li=-3.0)).severity is Severity.HARD
+    ) == is_storm_risk(-3.0)
 
 
 def test_daytime_clouds_clear_go():


### PR DESCRIPTION
## Problem

A thunderstorm produces a red forecast (the `atmospheric_stability` HARD veto on the lifted index), but the Urfeld gust front can still register session-strength wind — which the calibration then labelled GO. That made the storm rule look like an over-vetoer and risked eroding the very threshold that correctly called the storm. The wind is real, but it isn't a thermal session, so the day is uninformative (worse: misleading) for thermal-rule calibration.

## Change

- **`rules.is_storm_risk(min_lifted_index)`** — single source of truth, keyed on `LI ≤ MIN_LIFTED_INDEX`. Now also drives `atmospheric_stability`'s HARD veto, so the rule, the calibration quarantine, and the UI border can't drift apart.
- **`calibration.storm_suspected(record)` + `compile_report`** — storm days are excluded from the confusion matrix and per-rule offender stats, and counted in `Report.quarantined_days`. The text report prints a `⚡ N storm-suspected day(s) quarantined` line; the CSV export keeps a `storm_suspected` column rather than dropping rows silently (the ML notebook can mask or model them).
- **Dashboard** — black/yellow dashed "hazard" border on storm day-tabs and strip cells (legible even on a yellow MAYBE fill), with a bilingual tooltip and a matching legend entry.

Storm detection reuses the existing lifted-index signal — no new threshold or fetched field. CAPE/precipitation remain captured for a future tightening.

## Effect on accuracy

3 of 34 ground-truthed days are storm days. Excluding them, current-rules accuracy is 58% (duration label) / 61% (peak label) on n=31 — the forecast-GO band is the strong part (13/17 delivered).

## Tests

`pytest` (105 passing) covers the predicate, quarantine attribution, the report line, and the CSV column. `ruff` clean; `mypy` unchanged (2 pre-existing errors).